### PR TITLE
Reduce the chance of grenades landing at players feet.

### DIFF
--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -293,12 +293,10 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
                                      sfx::get_heard_angle( target ) );
         }
         // TODO: Z dispersion
-        // If we missed, just draw a straight line.
-        trajectory = line_to( source, target );
-    } else {
-        // Go around obstacles a little if we're on target.
-        trajectory = here.find_clear_path( source, target );
     }
+
+    //Use find clear path to draw the trajectory with optimal initial tile offsets.
+    trajectory = here.find_clear_path( source, target );
 
     add_msg_debug( debugmode::DF_BALLISTIC,
                    "missed_by_tiles: %.2f; missed_by: %.2f; target (orig/hit): %d,%d,%d/%d,%d,%d",


### PR DESCRIPTION
When a projectile misses the target tile, the trajectory calculation is changed. This patch makes it so that hits and misses use the same trajectory calculation for more natural results especially when close to a wall or other obstruction. The previous method of calculating trajectories would be greedy to take diagonals, and thus would often result in the projectile hitting an adjacent wall immediately. The new change will spread the impacts out more in distance.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Use find_clear_path always for projectile trajectories, not just when it hits.
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Make grenade throwing more natural, as even moderately skilled throwers are not going to drop them at their feet regularly.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Using the find_clear_path function as with hits will calculate an optimal offset even for target tiles out of LOS, this will cause the projectile to travel as far as it can before potentially crashing into a wall.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Generate a random offset for the initial throw.
Leave it as is.
Have a special flag for dangerous throwables and only having those projectiles use find_clear_path.
Change how accurate throwing is in general.
Make projectiles "bounce" off walls.


<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tried throwing several objects along a wall while peeking around a corner. Observed that the impacts to the wall were not all immediately adjacent to the player.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

Throwing grenades in cataclysm has always been exceptionally dangerous. Part of this is based on the fact that the throwing skill can't be reliably trained without fighting with throwing weapons. With low skills, and using the peek option to look around corners while throwing causes dispersion to be high, and with the previous trajectory calculation for misses, would lead to grenades droping at players feet quite often even with level 2 skill. This will somewhat alleviate that as the find_clear_path function will let projectiles travel further before impacting the wall.

This will have an affect on other projectiles as well, but even an untrained shooter is unlikely to shoot the wall next to them when trying to ain down a corridor, so I think any affects on other projectiles are reasonable.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
